### PR TITLE
Build Python 3.12 image on Ubuntu 24

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,9 @@ jobs:
           - ubuntu: 22.04
             python: 3.11
             label: 3.11
+          - ubuntu: 24.04
+            python: 3.12
+            label: 3.12
 
     # Start a local registry to which we will push trame-common, so that
     # docker buildx may access it in later steps.

--- a/docker/Dockerfile.common
+++ b/docker/Dockerfile.common
@@ -20,26 +20,42 @@ COPY --from=tianon/gosu /gosu /usr/local/bin/
 
 # Set up needed permissions and users
 # - User groups:
-#   - trame-user: non-priviledge user for running and accessing data
-#     => (optional) Provide runtime env TRAME_USER_DATA=/docker/path to query which user to map trame-user to
-#   - docker: group to be remapped to docker host group to allow docker in docker.
-#     - trame-user can perform docker operaction by allowing access to /var/run/docker.sock
+#   - trame-user: non-privileged user for running and accessing data
+#   - docker: group to be remapped to docker host group to allow docker in docker
 #   - proxy-mapping: group for r/w on mapping file
-#     - trame-user so the launcher can update the mapping file (w)
-#     - www-data so that apache can read the file and handle the network routing (r)
-#   - www-data: apache user
-#     - added to proxy-mapping so it can read the mapping file for routing network
-#     - added to trame-user so it can serve user data
-# - Magic numbers:
-#   - 1000: Default first user
-#   - 5001/5002: Large id to prevent conflict with existing host uid/gid
-RUN groupadd trame-user -g 1000 && \
-    groupadd proxy-mapping -g 5001 && \
-    groupadd docker -g 5002 && \
-    useradd -u 1000 -g trame-user -G proxy-mapping -s /sbin/nologin trame-user && \
-    usermod -a -G proxy-mapping www-data && \
-    usermod -a -G trame-user www-data && \
-    usermod -a -G docker trame-user && \
+# - Group IDs:
+#   - 5001: proxy-mapping
+#   - 5002: docker
+#   - 5003: trame-user (if UID 1000 already exists)
+RUN set -e && \
+    # Create groups with consistent GIDs
+    groupadd -f proxy-mapping -g 5001 && \
+    groupadd -f docker -g 5002 && \
+    # Handle user creation/modification based on whether UID 1000 exists
+    if getent passwd 1000 > /dev/null; then \
+      # User with UID 1000 already exists - adapt it
+      existing_user=$(getent passwd 1000 | cut -d: -f1) && \
+      existing_home=$(getent passwd 1000 | cut -d: -f6) && \
+      # Create trame-user group with a different GID to avoid conflicts
+      groupadd -f trame-user -g 5003 && \
+      # Rename user to trame-user for consistency
+      usermod -l trame-user $existing_user && \
+      # Set primary group to trame-user
+      usermod -g trame-user trame-user && \
+      # Add to necessary groups
+      usermod -a -G proxy-mapping,docker trame-user && \
+      # Set home directory if needed
+      if [ "$existing_home" != "/home/trame-user" ]; then \
+        usermod -d /home/trame-user trame-user; \
+      fi; \
+    else \
+      # No user with UID 1000 exists - create from scratch
+      groupadd -f trame-user -g 5003 && \
+      useradd -u 1000 -g trame-user -G proxy-mapping,docker -m -d /home/trame-user -s /sbin/nologin trame-user; \
+    fi && \
+    # Configure www-data user
+    usermod -a -G proxy-mapping,trame-user www-data && \
+    # Create necessary directories and set permissions
     mkdir -p /opt/trame && \
     chown -R trame-user:trame-user /opt/trame && \
     mkdir -p /home/trame-user && \


### PR DESCRIPTION
A second attempt to get the Python 3.12 build working on Ubuntu 24

fix https://github.com/Kitware/trame/pull/714
